### PR TITLE
Upgrade maven to 3.5.2 (require 3.1+)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a trivial web application to demonstrate the usage of the [lti-launch](h
 
 ### Tecnologies Used
 - Java 8
-- Apache Maven
+- Apache Maven (Compatible with 3.5.2, requires 3.1+)
 - Spring Boot (1.5.2)
 - Apache Tomcat
 - [LTI-Launch](https://github.com/kstateome/lti-launch) Library

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,26 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>1.4.1</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>[3.1,)</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Ensured this builds the same with Maven 3.5.2, but only requiring 3.1+ since this is open source and we don't want to be an unnecessary pain for others that are behind on maven.
LK 1480